### PR TITLE
Fix icon flipping rule

### DIFF
--- a/src/pages/i18n/Drawer.tsx
+++ b/src/pages/i18n/Drawer.tsx
@@ -48,8 +48,15 @@ const useStyles = makeStyles((theme: Theme) => ({
     RTL: { transform: 'scaleX(-1)' },
 }));
 
-// eslint-disable-next-line react/jsx-key
-const iconArray = [<HomeIcon />, <FolderIcon />, <ErrorIcon />, <SettingsIcon />, <HelpIcon />];
+type IconArrayType = { icon: React.ReactNode; flipRTL: boolean }[];
+
+const iconArray: IconArrayType = [
+    { icon: <HomeIcon />, flipRTL: false },
+    { icon: <FolderIcon />, flipRTL: false },
+    { icon: <ErrorIcon />, flipRTL: true },
+    { icon: <SettingsIcon />, flipRTL: false },
+    { icon: <HelpIcon />, flipRTL: true },
+];
 
 const menuItems = english.translations.MENU_ITEMS;
 
@@ -96,7 +103,11 @@ export const Drawer = (props: DrawerProps): JSX.Element => {
                             <InfoListItem
                                 dense
                                 title={t(`MENU_ITEMS.${menuItem}`)}
-                                icon={<div className={clsx(R2L && classes.RTL)}>{iconArray[index]}</div>}
+                                icon={
+                                    <div className={clsx(R2L && iconArray[index].flipRTL && classes.RTL)}>
+                                        {iconArray[index].icon}
+                                    </div>
+                                }
                                 key={menuItem}
                                 onClick={drawerToggler}
                                 style={R2L ? { textAlign: 'right' } : undefined}

--- a/src/pages/i18n/Drawer.tsx
+++ b/src/pages/i18n/Drawer.tsx
@@ -104,7 +104,7 @@ export const Drawer = (props: DrawerProps): JSX.Element => {
                                 dense
                                 title={t(`MENU_ITEMS.${menuItem}`)}
                                 icon={
-                                    <div className={clsx(R2L && iconArray[index].flipRTL && classes.RTL)}>
+                                    <div className={clsx({ [classes.RTL]: R2L && iconArray[index].flipRTL })}>
                                         {iconArray[index].icon}
                                     </div>
                                 }

--- a/src/pages/i18n/Drawer.tsx
+++ b/src/pages/i18n/Drawer.tsx
@@ -48,7 +48,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     RTL: { transform: 'scaleX(-1)' },
 }));
 
-type IconArrayType = { icon: React.ReactNode; flipRTL: boolean }[];
+type IconArrayType = Array<{ icon: React.ReactNode; flipRTL: boolean }>;
 
 const iconArray: IconArrayType = [
     { icon: <HomeIcon />, flipRTL: false },


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Flip only icons that should be flipped according to what I learned in https://github.com/pxblue/doc-it/pull/244

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
![image](https://user-images.githubusercontent.com/8997218/92187894-0731de80-ee29-11ea-9b37-0dd62fb98945.png)
only the question mark icon and the bang sign icon should be flipped.