### PR TITLE
Update selector to get list item root

### DIFF
--- a/cypress/integration/lists/sortable-list.spec.js
+++ b/cypress/integration/lists/sortable-list.spec.js
@@ -18,7 +18,7 @@ describe('Sortable list', () => {
 
     it('should drag item in list to location', () => {
       cy.get('[data-cy=edit-save]').click()
-      cy.get('[data-cy=sortable-row-0] > .MuiListItemIcon-root > .MuiSvgIcon-root')
+      cy.get('[data-cy=sortable-row-0] > .MuiListItemIcon-root')
       .trigger('mousedown', { which: 1 })
       .trigger('mousemove', { force: true, x: 0, y: 100 })
       .trigger('mouseup', { force: true })


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->


<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
-  Update test to grab list-item root with test id and drop path to not include icon
-  old - cy.get('[data-cy=sortable-row-0] > .MuiListItemIcon-root > .MuiSvgIcon-root')
-  new - cy.get('[data-cy=sortable-row-0] > .MuiListItemIcon-root')

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
