### PR TITLE
Animate the entire FAB button contents instead of just the icon

### DIFF
--- a/src/pages/loading-waiting-states/contextual-spinner/ContextualSpinner.tsx
+++ b/src/pages/loading-waiting-states/contextual-spinner/ContextualSpinner.tsx
@@ -4,7 +4,6 @@ import { AppBar, Toolbar, Hidden, IconButton, Typography, Button, Fab, CircularP
 import { TOGGLE_DRAWER } from '../../../redux/actions';
 import { useDispatch } from 'react-redux';
 import { Menu, PlayArrow } from '@material-ui/icons';
-import clsx from 'clsx';
 
 const useStyles = makeStyles((theme: Theme) => ({
     appbarRoot: {
@@ -149,19 +148,19 @@ export const ContextualSpinner = (): JSX.Element => {
                             className={isStartRoutineLoading ? classes.showAnimation : classes.hideAnimation}
                         />
                     ) : (
-                        <>
-                            <PlayArrow
-                                className={clsx([
-                                    classes.playArrow,
-                                    shouldAnimate
-                                        ? isStartRoutineLoading
-                                            ? classes.hideAnimation
-                                            : classes.showAnimation
-                                        : '',
-                                ])}
-                            />
+                        <span
+                            className={
+                                shouldAnimate
+                                    ? isStartRoutineLoading
+                                        ? classes.hideAnimation
+                                        : classes.showAnimation
+                                    : ''
+                            }
+                            style={{ display: 'inherit' }}
+                        >
+                            <PlayArrow className={classes.playArrow} />
                             Start Routine
-                        </>
+                        </span>
                     )}
                 </Fab>
             </div>


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes PXBLUE-2270.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Update the contextual spinner extended fab animation so it animates the entire contents rather than just the icons.
